### PR TITLE
Add files via upload

### DIFF
--- a/Vagrant_Readme.md
+++ b/Vagrant_Readme.md
@@ -1,0 +1,44 @@
+Atualização de 25-04-2017 19:48
+
+-A vagrant file irá criar uma máquina virtual com mysql e nodejs
+-Instalar o Vagrant de https://www.vagrantup.com/downloads.html
+-Instalar o Cygwin e nos plugins, instalar o openssh (procurar em net)
+-Instalar a Virtualbox (a máquina virtual irá ser criada na Virtualbox, mas não é necessario abrir a Virtualbox)
+-ir a linha de comandos e aceder a pasta onde está a Vagrantfile (Ex. cd\PSI\Trabalho)
+-Convem que esta pasta tenha os repositorios do GIT porque a máquina virtual mapeia a pasta onde está a VagrantFile tornando-a acessivel
+ a partir do sistema operativo Host e do Guest.
+- P.S. SE EXISTIR ALGUMA VAGRANT MACHINE CRIADA, UTILIZAR O COMANDO "vagrant destroy"
+ -executar o comando "vagrant up" dentro da pasta da VagrantFile, irá sacar a maquina e configurá-la de acordo com o ficheiro
+-para aceder por ssh, fazer "vagrant ssh" e terá acesso à shell da máquina (é necessário o cygwin instalado, com o putty não dá)
+-em shell do ubuntu, a pasta partilhada com o SO do host está em /vagrant (nao confundir com /home/vagrant). Esta pasta é a mesma onde está
+ a VagrantFile e tudo o que for aqui criado está sincronizado entre a máquina virtual e a pasta no host
+-para sair da shell fazer "exit" na shell da máquina virtual
+-para parar a máquina virtual, depois de ter saído da shell para a linha de comandos do Sistema operativo host, fazer "vagrant halt"
+-se quiser "destruir" a máquina virtual (por exemplo pra libertar espaço), basta fazer "vagrant destroy". A VagrantFile continua na pasta e
+ todo o processo pode ser repetido, no entanto todos os dados criados na maquina virtual são eliminados quando se faz "vagrant destroy"
+-Se quiser remover definitivamente a máquina virtual, fazer "vagrant box remove ubuntu/xenial64" (vagrant box remove nome_da_maquina)
+
+
+- Mysql Instalado
+- node js instalado
+- alteradas credenciais do root do mysql para a password '123qwe'
+- alterados os hosts com permissão para aceder ao mysql para todos (%)
+- alterado o bind-address do mysql para 0.0.0.0 e permitir ligação a partir de outros hosts
+- portas redirecionadas : 8080 -> 8080 (backend api), 3306 -> 33060 (mysql)
+- portas redirecionadas : 3000 -> 3000 e 3001 -> 3001 (frontend)
+- existe uma linha comentada de não utilização de links simbolicos para quem tiver problemas em 
+  linha de comandos de windows (de acordo com o André apenas em modo normal, em modo de Admin não dá erro)
+
+IMPORTANTE : Alguns colegas estão a ter problemas com a instalação automática do script da Vagrantfile.
+Em alguns casos foi detetado que tal se devia a terem a pasta do projecto numa path demasiado longa ou com
+caracteres especiais. Devem ter a pasta do projecto o mais junto da rais e numa pasta com o nome limpo, 
+exemplo : c:\PSI 
+e ter os repositorios clonados dentro dessa pasta
+
+para executar o servidor da aplicação, entrar na vagrant machine com "vagrant ssh" e fazer :
+cd /vagrant/projectary-api
+npm run frontend
+ou
+yarn run frontend
+
+e no host aceder a http://127.0.0.1:8080

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,7 +81,7 @@ override.vm.provision :shell, :inline => $script
 ## configura um reencaminhamento de portas da porta 8080 para a 8080 do host
 config.vm.network :forwarded_port, guest: 8080, host:8080, host_ip:"127.0.0.1"
 ## configura um reencaminhamento da porta 3306 (MySQL) para a porta 33060 do host
-config.vm.network :forwarded_port, guest: 3306, host:33060
+config.vm.network :forwarded_port, guest: 3306, host:33060, host_ip:"127.0.0.1"
 
 ## reencaminhamento de portas 3000 e 3001 para o host a pedido do André Santos
 config.vm.network :forwarded_port, guest:3000, host:3000, host_ip:"127.0.0.1"


### PR DESCRIPTION
Another parameter was added to port redirection clauses since some vagrant versions could present an error without it (1.9.2 was ok, 1.9.3 not ok without it).
You should have the project file closest to the root as possible and don't use special chars on it's name, ex : C:\PSI (point your repository inside this). Some errors may occur if you ignore this step